### PR TITLE
Fix individual compose files and reorganize main docker-compose (Lernie) service

### DIFF
--- a/Docker Stuff/Lernie/Lernie's Heads/Bazarr/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Bazarr/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   bazarr:
     image: lscr.io/linuxserver/bazarr:latest
@@ -6,13 +5,11 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - TZ=America/Los_Angeles
+      - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - ./config:/config
-      # substitute your value for {some_dir_ex_myMovies} for where your movies are kept
-      - {some_dir_ex_myMovies}:/movies
-      # substitute your value for {some_dir_ex_myShows} for where your movies are kept
-      - {some_dir_ex_myShows}:/shows
+      - /path/to/bazarr/config:/config # Set this
+      - /path/to/movies:/movies # Set this (optional but recommended in most cases)
+      - /path/to/tv:/tv # Set this (optional but recommended in most cases)
     ports:
       - 6767:6767
     restart: unless-stopped

--- a/Docker Stuff/Lernie/Lernie's Heads/Bazarr/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Bazarr/docker-compose.yaml
@@ -7,9 +7,9 @@ services:
       - PGID=1000
       - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - /path/to/bazarr/config:/config # Set this
-      - /path/to/movies:/movies # Set this (optional but recommended in most cases)
-      - /path/to/tv:/tv # Set this (optional but recommended in most cases)
+      - /path/to/bazarr/config:/config # Change this to your desired path
+      - /path/to/movies:/movies # Change this to your desired path (optional but recommended in most cases)
+      - /path/to/tv:/tv # Change this to your desired path (optional but recommended in most cases)
     ports:
       - 6767:6767
     restart: unless-stopped

--- a/Docker Stuff/Lernie/Lernie's Heads/Cloudflared_Tunnel/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Cloudflared_Tunnel/docker-compose.yaml
@@ -1,16 +1,11 @@
-version: "3.8"
 services:
   cloudflare_tunnel:
     image: cloudflare/cloudflared:latest
-    # Change {some_name} to the name of your choosing
-    container_name: {some_name}
-    restart: unless-stopped
-    # ${TUNNEL_TOKEN} should come from a .env file with the format of 'TUNNEL_TOKEN=_some_token_value_'
-    command: tunnel run --token ${TUNNEL_TOKEN}
-    network_mode: host
-    volumes:
-      - ./cloudflared/data:/home/nonroot/.cloudflared/
+    container_name: river_styx # Change to the name of your choosing
     environment:
-	  # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
-
+      - TZ=America/New_York # set this to your own desired timezone
+    volumes:
+      - ./cloudflared/data:/home/nonroot/.cloudflared/ # Change this to your desired path
+    command: tunnel run --token ${TUNNEL_TOKEN} # ${TUNNEL_TOKEN} should come from a .env file with the format of 'TUNNEL_TOKEN=_some_token_value_'
+    network_mode: host
+    restart: unless-stopped

--- a/Docker Stuff/Lernie/Lernie's Heads/Jackett/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Jackett/docker-compose.yaml
@@ -1,19 +1,16 @@
----
-version: "2.1"
 services:
   jackett:
     image: lscr.io/linuxserver/jackett:latest
     container_name: jackett
-    network_mode: host
     environment:
       - PUID=1000
       - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
+      - TZ=America/New_York # set this to your own desired timezone
       - AUTO_UPDATE=true #optional
       - RUN_OPTS= #optional
     volumes:
-      - ./Jackett:/config
-      # substitute your value for {some_dir_ex_Downloads} for where your movies are kept
-      - {some_dir_ex_Downloads}:/downloads
+      - /path/to/data:/config # Change this to your desired path
+      - /path/to/blackhole:/downloads # Change this to your desired path
+    ports:
+      - 9117:9117
     restart: unless-stopped

--- a/Docker Stuff/Lernie/Lernie's Heads/Overseerr/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Overseerr/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   overseerr:
     image: lscr.io/linuxserver/overseerr:latest
@@ -6,11 +5,9 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
+      - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - ./appdata/config:/config
+      - /path/to/overseerr/config:/config # Change this to your desired path
     ports:
       - 5055:5055
     restart: unless-stopped
-

--- a/Docker Stuff/Lernie/Lernie's Heads/Plex/docker-compose.yml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Plex/docker-compose.yml
@@ -1,25 +1,21 @@
-version: "3.3"
 services:
   plex:
     image: lscr.io/linuxserver/plex:latest
-    #image: plexinc/pms-docker
     container_name: plex
     network_mode: host
     environment:
       - PUID=1000
       - PGID=1000
+      - TZ=America/New_York # set this to your own desired timezone
       - VERSION=docker
       - PLEX_CLAIM={PLEX_CLAIM}
       - UMASK_SET=022
-      - TZ=America/Los_Angeles
     volumes:
-      - ./config:/config
-      # substitute your value for {some_dir_ex_myShows} for where your movies are kept
-      - {some_dir_ex_myShows}:/shows
-      # substitute your value for {some_dir_ex_myMovies} for where your movies are kept
-      - {some_dir_ex_myMovies}:/movies
-      - ./config/Library/Application Support/Plex Media Server/Transcode:/transcode
-      - ./config/Library/Application Support/Plex Media Server:/data
+      - /path/to/library:/config
+      - /path/to/tvseries:/shows # Change this to your desired path
+      - /path/to/movies:/movies # Change this to your desired path
+      - /dev/shm:/transcode # This is optional and uses RAM to speed up transcoding
+      - /path/to/Library/Application Support/Plex Media Server:/data # All data Plex uses and generates (e.g. watch history) lives here
     devices:
      - /dev/dri:/dev/dri
     restart: unless-stopped

--- a/Docker Stuff/Lernie/Lernie's Heads/Radarr/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Radarr/docker-compose.yaml
@@ -1,20 +1,16 @@
-version: "2.1"
 services:
   radarr:
     image: lscr.io/linuxserver/radarr:latest
     container_name: radarr
-    network_mode: host
     environment:
       - PUID=1000
       - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
+      - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - ./config/radarr:/config
-      # substitute your value for {some_dir_ex_myMovies} for where your movies are kept
-      - {some_dir_ex_myMovies}:/movies
-      # substitute your value for {some_dir_ex_Downloads} for where your movies are kept
-      - {some_dir_ex_Downloads}:/downloads
-      # substitute your value for {some_dir_ex_Backups} for where your movies are kept
-      - {some_dir_ex_Backups}:/var/backups
+      - /path/to/radarr/data:/config
+      - /path/to/movies:/movies # Change this to your desired path
+      - /path/to/download-client-downloads:/downloads # Change this to your desired path
+      - /path/to/backups:/var/backups # Change this to your desired path; optional but recommended to restore your Radarr data later
+    ports:
+      - 7878:7878
     restart: unless-stopped

--- a/Docker Stuff/Lernie/Lernie's Heads/Sonarr/docker-compose.yaml
+++ b/Docker Stuff/Lernie/Lernie's Heads/Sonarr/docker-compose.yaml
@@ -1,20 +1,16 @@
-version: "2.1"
 services:
   sonarr:
     image: lscr.io/linuxserver/sonarr:latest
     container_name: sonarr
-    network_mode: host
     environment:
       - PUID=1000
       - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
+      - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - ./config/sonarr:/config
-       # substitute your value for {some_dir_ex_myShows} for where your movies are kept
-      - {some_dir_ex_myShows}:/shows
-      # substitute your value for {some_dir_ex_Downloads} for where your movies are kept
-      - {some_dir_ex_Downloads}:/downloads
-      # substitute your value for {some_dir_ex_Backups} for where your movies are kept
-      - {some_dir_ex_Backups}:/var/backups
+      - /path/to/data:/config # Change this to your desired path
+      - /path/to/tvseries:/tv # Change this to your desired path
+      - /path/to/downloadclient-downloads:/downloads # Change this to your desired path
+      - /path/to/backups:/var/backups # Change this to your desired path; optional but recommended to restore your Radarr data later
+    ports:
+      - 8989:8989
     restart: unless-stopped

--- a/Docker Stuff/Lernie/docker-compose.yaml
+++ b/Docker Stuff/Lernie/docker-compose.yaml
@@ -1,133 +1,116 @@
 # This includes Plex and containers to support Plex (e.g. Sonarr or Bazarr) as well as a Cloudflare tunnel for remote access
 services:
-###############  Media-fetching Containers  ################
-  sonarr:
-    image: lscr.io/linuxserver/sonarr:latest
-    container_name: sonarr
-    network_mode: host
-    environment:
-      - PUID=1000
-      - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
-    volumes:
-      - ./config/sonarr:/config
-       # substitute your value for {some_dir_ex_myShows} for where your movies are kept
-      - {some_dir_ex_myShows}:/shows
-      # substitute your value for {some_dir_ex_Downloads} for where your movies are kept
-      - {some_dir_ex_Downloads}:/downloads
-      # substitute your value for {some_dir_ex_Backups} for where your movies are kept
-      - {some_dir_ex_Backups}:/var/backups
-    restart: unless-stopped
+###############  Media-managment Containers  ################
+  bazarr: # For subtitles
+      image: lscr.io/linuxserver/bazarr:latest
+      container_name: bazarr
+      environment:
+        - PUID=1000
+        - PGID=1000
+        - TZ=America/New_York # set this to your own desired timezone
+      volumes:
+        - /path/to/bazarr/config:/config # Set this
+        - /path/to/movies:/movies # Set this (optional but recommended in most cases)
+        - /path/to/tv:/tv # Set this (optional but recommended in most cases)
+      ports:
+        - 6767:6767
+      restart: unless-stopped
   
-  radarr:
-    image: lscr.io/linuxserver/radarr:latest
-    container_name: radarr
-    network_mode: host
-    environment:
-      - PUID=1000
-      - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
-    volumes:
-      - ./config/radarr:/config
-      # substitute your value for {some_dir_ex_myMovies} for where your movies are kept
-      - {some_dir_ex_myMovies}:/movies
-      # substitute your value for {some_dir_ex_Downloads} for where your movies are kept
-      - {some_dir_ex_Downloads}:/downloads
-      # substitute your value for {some_dir_ex_Backups} for where your movies are kept
-      - {some_dir_ex_Backups}:/var/backups
-    restart: unless-stopped
-
-  jackett:
-    image: lscr.io/linuxserver/jackett:latest
-    container_name: jackett
-    network_mode: host
-    environment:
-      - PUID=1000
-      - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
-      - AUTO_UPDATE=true #optional
-      - RUN_OPTS= #optional
-    volumes:
-      - ./Jackett:/config
-      # substitute your value for {some_dir_ex_Downloads} for where your movies are kept
-      - {some_dir_ex_Downloads}:/downloads
-    restart: unless-stopped
-
-  ###############  Media-managment Containers  ################
-  bazarr:
-    image: lscr.io/linuxserver/bazarr:latest
-    container_name: bazarr
-    environment:
-      - PUID=1000
-      - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
-    volumes:
-      - ./config:/config
-      # substitute your value for {some_dir_ex_myMovies} for where your movies are kept
-      - {some_dir_ex_myMovies}:/movies
-      # substitute your value for {some_dir_ex_myShows} for where your movies are kept
-      - {some_dir_ex_myShows}:/shows
-    ports:
-      - 6767:6767
-    restart: unless-stopped
-
-  overseerr:
+  overseerr: # For media requests and issues
     image: lscr.io/linuxserver/overseerr:latest
     container_name: overseerr
     environment:
       - PUID=1000
       - PGID=1000
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
+      - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - ./appdata/config:/config
+      - /path/to/overseerr/config:/config # Change this to your desired path
     ports:
       - 5055:5055
     restart: unless-stopped
 
-  ###############  Media-Streaming Containers  ################
-  plex:
-    image: lscr.io/linuxserver/plex:latest
-    #image: plexinc/pms-docker
-    container_name: plex
-    network_mode: host
+  radarr: # For movie management
+    image: lscr.io/linuxserver/radarr:latest
+    container_name: radarr
     environment:
       - PUID=1000
       - PGID=1000
-      - VERSION=docker
-      - PLEX_CLAIM={PLEX_CLAIM}
-      - UMASK_SET=022
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}
+      - TZ=America/New_York # set this to your own desired timezone
     volumes:
-      - ./config:/config
-      # substitute your value for {some_dir_ex_myShows} for where your movies are kept
-      - {some_dir_ex_myShows}:/shows
-      # substitute your value for {some_dir_ex_myMovies} for where your movies are kept
-      - {some_dir_ex_myMovies}:/movies
-      - ./config/Library/Application Support/Plex Media Server/Transcode:/transcode
-      - ./config/Library/Application Support/Plex Media Server:/data
-    devices:
-     - /dev/dri:/dev/dri
+      - /path/to/radarr/data:/config
+      - /path/to/movies:/movies # Change this to your desired path
+      - /path/to/download-client-downloads:/downloads # Change this to your desired path
+      - /path/to/backups:/var/backups # Change this to your desired path; optional but recommended to restore your Radarr data later
+    ports:
+      - 7878:7878
     restart: unless-stopped
-  
+
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:latest
+    container_name: sonarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/New_York # set this to your own desired timezone
+    volumes:
+      - /path/to/data:/config # Change this to your desired path
+      - /path/to/tvseries:/tv # Change this to your desired path
+      - /path/to/downloadclient-downloads:/downloads # Change this to your desired path
+      - /path/to/backups:/var/backups # Change this to your desired path; optional but recommended to restore your Radarr data later
+    ports:
+      - 8989:8989
+    restart: unless-stopped
+
+###############  Networking-management  ################
+  cloudflare_tunnel: # For remote access
+      image: cloudflare/cloudflared:latest
+      container_name: river_styx # Change to the name of your choosing
+      environment:
+        - TZ=America/New_York # set this to your own desired timezone
+      volumes:
+        - ./cloudflared/data:/home/nonroot/.cloudflared/ # Change this to your desired path
+      command: tunnel run --token ${TUNNEL_TOKEN} # ${TUNNEL_TOKEN} should come from a .env file with the format of 'TUNNEL_TOKEN=_some_token_value_'
+      network_mode: host
+      restart: unless-stopped
+
+###############  Media-fetching Containers  ################
+  jackett: # For torrent/indexer searching
+      image: lscr.io/linuxserver/jackett:latest
+      container_name: jackett
+      environment:
+        - PUID=1000
+        - PGID=1000
+        - TZ=America/New_York # set this to your own desired timezone
+        - AUTO_UPDATE=true #optional
+        - RUN_OPTS= #optional
+      volumes:
+        - /path/to/data:/config # Change this to your desired path
+        - /path/to/blackhole:/downloads # Change this to your desired path
+      ports:
+        - 9117:9117
+      restart: unless-stopped
+
+###############  Media-Streaming Containers  ################
+  plex:
+      image: lscr.io/linuxserver/plex:latest
+      container_name: plex
+      network_mode: host
+      environment:
+        - PUID=1000
+        - PGID=1000
+        - TZ=America/New_York # set this to your own desired timezone
+        - VERSION=docker
+        - PLEX_CLAIM={PLEX_CLAIM}
+        - UMASK_SET=022
+      volumes:
+        - /path/to/library:/config
+        - /path/to/tvseries:/shows # Change this to your desired path
+        - /path/to/movies:/movies # Change this to your desired path
+        - /dev/shm:/transcode # This is optional and uses RAM to speed up transcoding
+        - ./path/to/Library/Application Support/Plex Media Server:/data # All data Plex uses and generates (e.g. watch history) lives here
+      devices:
+      - /dev/dri:/dev/dri
+      restart: unless-stopped
+      
   # TODO: Consider adding Jellyfin or Kodi or Emby as an alternative to Plex
 
-  ###############  Networking-management  ################
-  cloudflare_tunnel:
-    image: cloudflare/cloudflared:latest
-    # Change {some_name} to the name of your choosing
-    container_name: {some_name}
-    restart: unless-stopped
-    # ${TUNNEL_TOKEN} should come from a .env file with the format of 'TUNNEL_TOKEN=_some_token_value_'
-    command: tunnel run --token ${TUNNEL_TOKEN}
-    network_mode: host
-    volumes:
-      - ./cloudflared/data:/home/nonroot/.cloudflared/
-    environment:
-      # Change {some_TZ} to your TZ
-      - TZ=America/{some_TZ}


### PR DESCRIPTION
This PR does two things:

1) Clean up the templates for the stand-alone docker-compose services (e.g. just Radarr or Plex; these are the individual heads of Lernie)
2) Clean up the template for the main docker-compose service (i.e all the stand-alone containers as one service on one docker-compose file; this is Lernie in its entirety)

